### PR TITLE
refactor(react-query): remove `useQuery` overloads in favour of generic

### DIFF
--- a/packages/react-query/src/useQuery.ts
+++ b/packages/react-query/src/useQuery.ts
@@ -7,41 +7,20 @@ import type {
   UseQueryOptions,
   UseQueryResult,
 } from './types'
-import type {
-  DefinedInitialDataOptions,
-  UndefinedInitialDataOptions,
-} from './queryOptions'
 
 export function useQuery<
   TQueryFnData = unknown,
   TError = DefaultError,
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
+  TInitialData = unknown,
 >(
-  options: UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>,
+  options: UseQueryOptions<TQueryFnData, TError, TData, TQueryKey> & {
+    initialData?: TInitialData
+  },
   queryClient?: QueryClient,
-): UseQueryResult<TData, TError>
-
-export function useQuery<
-  TQueryFnData = unknown,
-  TError = DefaultError,
-  TData = TQueryFnData,
-  TQueryKey extends QueryKey = QueryKey,
->(
-  options: DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>,
-  queryClient?: QueryClient,
-): DefinedUseQueryResult<TData, TError>
-
-export function useQuery<
-  TQueryFnData = unknown,
-  TError = DefaultError,
-  TData = TQueryFnData,
-  TQueryKey extends QueryKey = QueryKey,
->(
-  options: UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
-  queryClient?: QueryClient,
-): UseQueryResult<TData, TError>
-
-export function useQuery(options: UseQueryOptions, queryClient?: QueryClient) {
-  return useBaseQuery(options, QueryObserver, queryClient)
+): TInitialData extends TQueryFnData | (() => TQueryFnData)
+  ? DefinedUseQueryResult<TData, TError>
+  : UseQueryResult<TData, TError> {
+  return useBaseQuery(options, QueryObserver, queryClient) as any
 }


### PR DESCRIPTION
Found a way to remove the overloads of the `useQuery` function by using a new generic `TInitialData`.

Pros:
- Smaller code footprint
- No overloads
- Presumably no breaking changes since tests are passing
- I think this is easier to read but I could totally understand someone thinking this is more difficult to read

Cons:
- Extra generic param
- `as any` to fix return type mismatch